### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/check-zonemaster.py
+++ b/check-zonemaster.py
@@ -105,7 +105,7 @@ msg = {
         }
 
 # Start building the command
-subprocess_args = re.split('\s+', command)
+subprocess_args = re.split(r'\s+', command)
 
 # Set profile/policy options
 if profile is not None:


### PR DESCRIPTION
Fix warning:

```
./check-zonemaster.py:108: SyntaxWarning: invalid escape sequence '\s'
  subprocess_args = re.split('\s+', command)
```